### PR TITLE
SonarTfsAnnotate needs 3 parameters to work correctly (file, user, password)

### DIFF
--- a/SonarTfsAnnotate/Properties/AssemblyInfo.cs
+++ b/SonarTfsAnnotate/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/SonarTfsAnnotate/SonarTfsAnnotate.csproj
+++ b/SonarTfsAnnotate/SonarTfsAnnotate.csproj
@@ -36,6 +36,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.TeamFoundation.Common, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.VersionControl.Client.dll</HintPath>


### PR DESCRIPTION
There are some cases that it's necessary connect to TFS with a specific user and password. Hence, I improved the SonarTfsAnnotate to accept 3 parameters, and try to authenticate with TFS. If the user can't be authenticated, I show an error message  in the console and exit.