### PR TITLE
Prevent crash when annotating encoding-less file.

### DIFF
--- a/SonarTfsAnnotate/HistoryProvider.cs
+++ b/SonarTfsAnnotate/HistoryProvider.cs
@@ -108,6 +108,7 @@ namespace SonarSource.TfsAnnotate
             }
             if (manualResetEvents[i] != null)
             {
+                manualResetEvents[i].WaitOne();
                 manualResetEvents[i].Dispose();
                 manualResetEvents[i] = null;
             }


### PR DESCRIPTION
In the case of an eager return from FileAnnotator:Annotate, such as for a binary or encoding-less file, TFS annotate will crash with an object disposed exception. This is because the Prefetch that started in the constructor on background threads could still be going on if the file has alot of history. Then when Prefetcher:Prefetch calls manualResetEvent.Set an Object disposed exception is thrown.

The correct fix is probably to replace all of the prefetch stuff with tasks instead of using QueueUserWorkItem and cancel them. That way we don't do all the downloads if we don't need them. I'll submit a separate pull request with that. This is the safest fix for a short release timeframe.